### PR TITLE
Commented out docker version command. Simply need to mount host socke…

### DIFF
--- a/jenkins-pipeline-tooling/install-docker.sh
+++ b/jenkins-pipeline-tooling/install-docker.sh
@@ -46,5 +46,5 @@ apt-get -y install docker-ce=${DOCKER_VERSION}
 #Print current user to see if root
 whoami
 
-#Print docker version. Problem is the docker.sock (docker socket) did not get added under /var/run
-docker version
+#Cannot use docker daemon unless you mount the host socket when running the image. docker run -v /var/run/docker.sock:/var/run/docker.sock -it jenkins-pipeline-tooling:latest bash
+#docker version


### PR DESCRIPTION
Commented out docker version command. Simply need to mount host socket when running docker run.

Ex: docker run -v /var/run/docker.sock:/var/run/docker.sock -it jenkins-pipeline-tooling:latest bash

Run in --privileged=true if want to be able to use service docker start or other service commands.